### PR TITLE
Support `SELECT * EXCEPT (col1, col2)`-style functionality

### DIFF
--- a/resources/inferenceql/query/base.bnf
+++ b/resources/inferenceql/query/base.bnf
@@ -76,11 +76,13 @@ distinct-clause ::= #'(?i)DISTINCT'
 
 select-clause ::= #'(?i)SELECT' (ws distinct-clause)? ws select-list
 
-select-list ::= star
+select-list ::= select-star-clause
               / selection (ws? ',' ws? selection)*
               / aggregation (ws? ',' ws? aggregation)*
 
+select-star-clause ::= star (ws? select-except-clause)?
 star ::= '*'
+select-except-clause ::= #'(?i)EXCEPT' ws? '(' ws? identifier-list ws? ')'
 
 selection ::= (scalar-expr | aggregation) (ws alias-clause)?
 
@@ -149,7 +151,6 @@ insert-expr ::= #'(?i)INSERT' ws #'(?i)INTO' ws relation-expr ws relation-expr
 
 relation-value ::= '(' ws? identifier-list ws? ')' ws #'(?i)VALUES' ws value-lists
 
-identifier-list ::= identifier (ws? ',' ws identifier)*
 value-list ::= '(' ws? value (ws? ',' ws? value)* ws? ')'
 value-lists ::= value-lists-full | value-lists-sparse
 value-lists-full ::= value-list (ws? ',' ws? value-list)*
@@ -241,6 +242,7 @@ bool             ::= #'true|false'
 float            ::= #'-?\d+\.\d+(E-?\d+)?'
 int              ::= #'-?\d+'
 nat              ::= #'\d+'
+identifier-list  ::= identifier (ws? ',' ws? identifier)*
 identifier       ::= simple-symbol | delimited-symbol
 simple-symbol    ::= #'(?u)(?!G__)\p{L}[\p{L}\p{N}_\-\?\.]*'
 delimited-symbol ::= <'"'> #'[^\"]+' <'"'>

--- a/src/inferenceql/query/base.cljc
+++ b/src/inferenceql/query/base.cljc
@@ -22,14 +22,14 @@
   - parse - a parsing function"
   [s db parse]
   (let [node-or-failure (parse s)]
+    (tap> #:base.query{:node node-or-failure})
     (cond (insta/failure? node-or-failure)
           (throw (error/parse node-or-failure))
 
           (plan/relation-node? node-or-failure)
           (let [plan (plan/plan node-or-failure)
                 env (db/env @db)]
-            (tap> #:base.query{:node node-or-failure
-                               :plan plan
+            (tap> #:base.query{:plan plan
                                :env env})
             (plan/eval plan env {}))
 

--- a/src/inferenceql/query/parser/tree.cljc
+++ b/src/inferenceql/query/parser/tree.cljc
@@ -40,7 +40,7 @@
            (string/blank? node))))
 
 (defn children
-  "Returns `node`'s children."
+  "Returns `node`'s children. Removes whitespace nodes."
   [node]
   (into []
         (clojure/remove whitespace?)

--- a/src/inferenceql/query/relation.cljc
+++ b/src/inferenceql/query/relation.cljc
@@ -74,6 +74,7 @@
               :attrs (mapv second coll))))
 
 (defn select
+  "Selects/filters the tuples/rows that match the pred fn"
   [rel pred]
   (with-meta (filter pred (tuples rel))
     (meta rel)))
@@ -111,6 +112,14 @@
                          (conj (attributes rel)
                                attr))]
     (relation rel :attrs attributes)))
+
+(defn remove-attributes
+  "Remove attributes from a relation."
+  [rel attrs]
+  (let [attributes' (remove (set attrs)
+                            (attributes rel))]
+    (-> (map #(apply dissoc % attrs) rel)
+        (relation :attrs attributes'))))
 
 (defn group-by
   [rel f]

--- a/src/inferenceql/query/tuple.cljc
+++ b/src/inferenceql/query/tuple.cljc
@@ -22,10 +22,10 @@
   (map? x))
 
 (defn select-attrs
-  "Retrives tuple `tup` with only the attributes in `attrs`."
+  "Retrieves tuple `tup` with only the attributes in `attrs`."
   [tup attrs]
-  (let [names (into #{} (map name) attrs)]
-    (medley/filter-keys (comp names name)
+  (let [names (into #{} (map clojure.core/name) attrs)]
+    (medley/filter-keys (comp names clojure.core/name)
                         tup)))
 
 (defn ->map

--- a/test/inferenceql/query/plan_test.cljc
+++ b/test/inferenceql/query/plan_test.cljc
@@ -17,6 +17,7 @@
     "SELECT * FROM data"
     "SELECT x FROM data"
     "SELECT (x) FROM data"
+    "SELECT * EXCEPT (foo, bar) FROM data"
     "SELECT PROBABILITY OF VAR x = x UNDER model FROM data"
     "SELECT (PROBABILITY OF VAR x = x UNDER model) FROM data"))
 
@@ -29,6 +30,7 @@
     "SELECT * FROM data"
     "SELECT x FROM data"
     "SELECT (x) FROM data"
+    "SELECT * EXCEPT (foo, bar) FROM data"
     "SELECT PROBABILITY OF x UNDER model FROM data"
     "SELECT (PROBABILITY OF x UNDER model) FROM data"))
 
@@ -73,7 +75,6 @@
       "SELECT * FROM data;" [{"x" 0 "y" 1}] ["x"]     ["x"]
       "SELECT * FROM data;" [{"x" 0}]       ["x" "y"] ["x" "y"]
       "SELECT x FROM data;" [{}]            ["x"]     ["x"]))
-
 
   (testing "from aliasing"
     (are [query in attrs expected] (= expected

--- a/test/inferenceql/query/strict/parser_test.cljc
+++ b/test/inferenceql/query/strict/parser_test.cljc
@@ -11,7 +11,8 @@
     "SELECT x AS y FROM data"
     "SELECT (x) FROM data"
     "SELECT (x) AS y FROM data"
-    "SELECT avg(x) FROM data"))
+    "SELECT avg(x) FROM data"
+    "SELECT * EXCEPT (foo, bar) FROM data"))
 
 (deftest select-invalid
   (are [s] (insta/failure? (parser/parse s))

--- a/test/inferenceql/query/strict_test.cljc
+++ b/test/inferenceql/query/strict_test.cljc
@@ -113,7 +113,7 @@
 (defspec select-star-except
   (prop/for-all [[table ks] gen-table-col-subset]
     (let [kset (set ks)
-          col-list (->> ks #_ (map name) (string/join ", "))
+          col-list (->> ks (string/join ", "))
           results (q (str "SELECT * EXCEPT (" col-list ") FROM data") table)]
       (is (every? (every-pred #(empty? (select-keys % ks))
                               #(empty? (set/intersection kset (set (keys %)))))


### PR DESCRIPTION
This adds `SELECT * EXCEPT (col-i-dont-want, col-that-annoys-me) ...` functionality to GenSQL.

Adding `* EXCEPT` to other areas (conditioning, generation) will come in future PRs.