### PR TITLE
Get code coverage actually working

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -46,7 +46,9 @@ jobs:
 
       - name: generate coverage report
         run: |
-            CLOVERAGE_VERSION=1.2.4 clojure -M:test:coverage --codecov || :
+            CLOVERAGE_VERSION=1.2.4 clojure -M:test:clj-test:coverage \
+            --ns-exclude-regex "inferenceql.query.plan.viz" \
+            --codecov || :
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4.0.1


### PR DESCRIPTION
I had to go in and exclude the `viz` namespace, which was giving the instrumentation for code coverage trouble. It's never touched from the test so no problem here.