### PR TITLE
build: enable opt-in readonly deps

### DIFF
--- a/deps-lock.json
+++ b/deps-lock.json
@@ -11,10 +11,9 @@
     {
       "lib": "io.github.cognitect-labs/test-runner",
       "url": "https://github.com/cognitect-labs/test-runner.git",
-      "rev": "dfb30dd6605cb6c0efc275e1df1736f6e90d4d73",
-      "tag": "v0.5.1",
+      "rev": "7284cda41fb9edc0f3bc6b6185cfb7138fc8a023",
       "git-dir": "https/github.com/cognitect-labs/test-runner",
-      "hash": "sha256-PUNd+dHJNPTKno59YI27wpehyULYPvSyCQDjVIadKJ4="
+      "hash": "sha256-/opMnUA5tnUFZrDr34ug1Zy5hWnuYNap6yf3iJAGkLw="
     },
     {
       "lib": "io.github.inferenceql/inferenceql.inference",
@@ -146,6 +145,16 @@
       "mvn-path": "cljs-bean/cljs-bean/1.8.0/cljs-bean-1.8.0.pom",
       "mvn-repo": "https://repo.clojars.org/",
       "hash": "sha256-xMtL7gH6hnrFu8XPdgT+g+022A6zpQD9+qkuObEW7nQ="
+    },
+    {
+      "mvn-path": "cloverage/cloverage/1.2.4/cloverage-1.2.4.jar",
+      "mvn-repo": "https://repo.clojars.org/",
+      "hash": "sha256-pmnEN8oahyohS+2aacY4VKql7EGMrM21ijipsxQQJQ8="
+    },
+    {
+      "mvn-path": "cloverage/cloverage/1.2.4/cloverage-1.2.4.pom",
+      "mvn-repo": "https://repo.clojars.org/",
+      "hash": "sha256-n0sJ40YL4OFuAt7ol6BjL0JF9zbVo+Z+y7URF6IzUkc="
     },
     {
       "mvn-path": "com/andrewmcveigh/cljs-time/0.5.2/cljs-time-0.5.2.jar",
@@ -1598,6 +1607,16 @@
       "hash": "sha256-F3i70Ti9GFkLgFS+nZGdG+toCfhbduXGKFtn1Ad9MA4="
     },
     {
+      "mvn-path": "org/clojure/data.codec/0.1.0/data.codec-0.1.0.jar",
+      "mvn-repo": "https://repo.maven.apache.org/maven2/",
+      "hash": "sha256-aD1oGVBAPGHCNjVBgeuhtcja9sE1geoTiZNKfV6yjgc="
+    },
+    {
+      "mvn-path": "org/clojure/data.codec/0.1.0/data.codec-0.1.0.pom",
+      "mvn-repo": "https://repo.maven.apache.org/maven2/",
+      "hash": "sha256-8T2ZaEbW16cCQ2JlqjhjKmdGkgJaQYpWaVxQKBPd2ng="
+    },
+    {
       "mvn-path": "org/clojure/data.csv/1.0.1/data.csv-1.0.1.jar",
       "mvn-repo": "https://repo.maven.apache.org/maven2/",
       "hash": "sha256-gTpWu971A7Y1CswhrG9/YKLF2wi+wQpF60uRfmbtE04="
@@ -1626,6 +1645,16 @@
       "mvn-path": "org/clojure/data.priority-map/1.1.0/data.priority-map-1.1.0.pom",
       "mvn-repo": "https://repo.maven.apache.org/maven2/",
       "hash": "sha256-RlIA+U9W2IaOD9eqC+zGL/sCz69CCkmtEXkQ5jr13/4="
+    },
+    {
+      "mvn-path": "org/clojure/data.xml/0.2.0-alpha6/data.xml-0.2.0-alpha6.jar",
+      "mvn-repo": "https://repo.maven.apache.org/maven2/",
+      "hash": "sha256-kIgrSsb2EOX9cR+IVUWkkJAjtj2OfVlZGNl9GBtZqCg="
+    },
+    {
+      "mvn-path": "org/clojure/data.xml/0.2.0-alpha6/data.xml-0.2.0-alpha6.pom",
+      "mvn-repo": "https://repo.maven.apache.org/maven2/",
+      "hash": "sha256-H4iAueskhGhsnso8MGhF2NuR52pNHF9kV1VO3synYzY="
     },
     {
       "mvn-path": "org/clojure/data.xml/0.2.0-alpha8/data.xml-0.2.0-alpha8.jar",
@@ -1676,6 +1705,11 @@
       "mvn-path": "org/clojure/math.combinatorics/0.1.6/math.combinatorics-0.1.6.pom",
       "mvn-repo": "https://repo.maven.apache.org/maven2/",
       "hash": "sha256-5YEc6YpDSIBkBV4/jS8jXEbcdEL4f3dBMIcBOawhKp8="
+    },
+    {
+      "mvn-path": "org/clojure/pom.contrib/0.0.25/pom.contrib-0.0.25.pom",
+      "mvn-repo": "https://repo.maven.apache.org/maven2/",
+      "hash": "sha256-68ezduVtg/bEhM2x03Hv3AEw3bvK3n1tpuNU9OQm/Is="
     },
     {
       "mvn-path": "org/clojure/pom.contrib/0.1.2/pom.contrib-0.1.2.pom",
@@ -1801,6 +1835,16 @@
       "mvn-path": "org/clojure/tools.gitlibs/2.5.197/tools.gitlibs-2.5.197.pom",
       "mvn-repo": "https://repo.maven.apache.org/maven2/",
       "hash": "sha256-PX3x6lC6vAt6mbBqMLEAJqsxOqrKxLQGcyk3W8YIkGE="
+    },
+    {
+      "mvn-path": "org/clojure/tools.logging/0.5.0/tools.logging-0.5.0.jar",
+      "mvn-repo": "https://repo.maven.apache.org/maven2/",
+      "hash": "sha256-UA+0OR8s5xWNTLSQWOpI60LiTzdrboL8/ojJHeXewxo="
+    },
+    {
+      "mvn-path": "org/clojure/tools.logging/0.5.0/tools.logging-0.5.0.pom",
+      "mvn-repo": "https://repo.maven.apache.org/maven2/",
+      "hash": "sha256-230HS84slEV+bsKwUSg+Typ4oayhZNhPjYFhelVCkZ0="
     },
     {
       "mvn-path": "org/clojure/tools.logging/1.2.4/tools.logging-1.2.4.jar",
@@ -2183,36 +2227,6 @@
       "hash": "sha256-g2Bpyp6O48VuSDdiItopEmPxN70/0W2E/dR+/MPyhuI="
     },
     {
-      "mvn-path": "org/junit/jupiter/junit-jupiter-api/5.7.1/junit-jupiter-api-5.7.1.pom",
-      "mvn-repo": "https://repo.maven.apache.org/maven2/",
-      "hash": "sha256-1Vvisj13FDKXB3IEMgey5mpnJK4CvVGStyFuS3AbxiM="
-    },
-    {
-      "mvn-path": "org/junit/jupiter/junit-jupiter-engine/5.7.1/junit-jupiter-engine-5.7.1.pom",
-      "mvn-repo": "https://repo.maven.apache.org/maven2/",
-      "hash": "sha256-gRF+OjoCDf3W8wkcXseU0stJhAcxrPQogxxWmQEvTLs="
-    },
-    {
-      "mvn-path": "org/junit/jupiter/junit-jupiter-params/5.7.1/junit-jupiter-params-5.7.1.pom",
-      "mvn-repo": "https://repo.maven.apache.org/maven2/",
-      "hash": "sha256-UIPD5bw9OhjVY6M0fVPi3f35ONdh60TbsL9PQgX+6Sw="
-    },
-    {
-      "mvn-path": "org/junit/jupiter/junit-jupiter/5.7.1/junit-jupiter-5.7.1.pom",
-      "mvn-repo": "https://repo.maven.apache.org/maven2/",
-      "hash": "sha256-YLUGfK3Mb/tfqS6OJJiKgMbDYEaPJj0mmLKIHI4PfJE="
-    },
-    {
-      "mvn-path": "org/junit/platform/junit-platform-commons/1.7.1/junit-platform-commons-1.7.1.pom",
-      "mvn-repo": "https://repo.maven.apache.org/maven2/",
-      "hash": "sha256-t8GENMTUsn5yO9SKr5ercK7IwMra1MFTkvvdFEykpQo="
-    },
-    {
-      "mvn-path": "org/junit/platform/junit-platform-engine/1.7.1/junit-platform-engine-1.7.1.pom",
-      "mvn-repo": "https://repo.maven.apache.org/maven2/",
-      "hash": "sha256-dmAvWZVKo9+mjjHIDKibb7ouoAG0+wbLUfoV6tfIWjA="
-    },
-    {
       "mvn-path": "org/kohsuke/pom/14/pom-14.pom",
       "mvn-repo": "https://repo.maven.apache.org/maven2/",
       "hash": "sha256-FQ9F/ISliYf7KGU9+SntI5krV0Y24HoLPmXsu+LT7oM="
@@ -2296,6 +2310,11 @@
       "mvn-path": "org/slf4j/slf4j-parent/1.7.36/slf4j-parent-1.7.36.pom",
       "mvn-repo": "https://repo.maven.apache.org/maven2/",
       "hash": "sha256-uziNN/vN083mTDzt4hg4aTIY3EUfBAQMXfNgp47X6BI="
+    },
+    {
+      "mvn-path": "org/sonatype/oss/oss-parent/5/oss-parent-5.pom",
+      "mvn-repo": "https://repo.maven.apache.org/maven2/",
+      "hash": "sha256-FnjUEgpYXYpjATGu7ExSTZKDmFg7fqthbufVqH9SDT0="
     },
     {
       "mvn-path": "org/sonatype/oss/oss-parent/7/oss-parent-7.pom",
@@ -2383,6 +2402,16 @@
       "hash": "sha256-At+3ryDvgcJTZQVfYCjoscwpBdCyaLuJzEKM2nIwo2U="
     },
     {
+      "mvn-path": "riddley/riddley/0.2.0/riddley-0.2.0.jar",
+      "mvn-repo": "https://repo.clojars.org/",
+      "hash": "sha256-fbJ+6PUSkzITRXSYxGDXHYDVK1dkY/uR6IqxXQsijGg="
+    },
+    {
+      "mvn-path": "riddley/riddley/0.2.0/riddley-0.2.0.pom",
+      "mvn-repo": "https://repo.clojars.org/",
+      "hash": "sha256-Q4OCl25gdh6Va+oaZzdLuDYVbNnsa80eEKMMq9qLLFA="
+    },
+    {
       "mvn-path": "ring-cors/ring-cors/0.1.13/ring-cors-0.1.13.jar",
       "mvn-repo": "https://repo.clojars.org/",
       "hash": "sha256-ykElZhlNMX9s7clO4Fmwl6h3B6e+mzOMn1MheihvxIw="
@@ -2391,11 +2420,6 @@
       "mvn-path": "ring-cors/ring-cors/0.1.13/ring-cors-0.1.13.pom",
       "mvn-repo": "https://repo.clojars.org/",
       "hash": "sha256-SZCg3bNUDE1Ed6GtqP1mP62RSRScmaYGL7/XSKXwGJo="
-    },
-    {
-      "mvn-path": "ring/ring-codec/1.1.2/ring-codec-1.1.2.pom",
-      "mvn-repo": "https://repo.clojars.org/",
-      "hash": "sha256-sl/LVYL/wFWem+BnzQXP13SAm5IocZz8HqVojsnKH+c="
     },
     {
       "mvn-path": "ring/ring-codec/1.1.3/ring-codec-1.1.3.jar",

--- a/deps.edn
+++ b/deps.edn
@@ -28,7 +28,7 @@
            :build {:deps {io.github.clojure/tools.build {:git/sha "8e78bccc35116f6b6fc0bf0c125dba8b8db8da6b"}}
                    :ns-default build}
            :cljs {:extra-deps {thheller/shadow-cljs {:mvn/version "2.27.5"}}}
-           :clj-test {:extra-deps {io.github.cognitect-labs/test-runner {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
+           :clj-test {:extra-deps {io.github.cognitect-labs/test-runner {:git/sha "7284cda41fb9edc0f3bc6b6185cfb7138fc8a023"}}
                       :main-opts ["--main" "cognitect.test-runner"]
                       :exec-fn cognitect.test-runner.api/test}
            :cljs-test {:extra-deps {olical/cljs-test-runner {:mvn/version "3.8.0"}}

--- a/flake.nix
+++ b/flake.nix
@@ -58,6 +58,35 @@
 
           shellHook = ''
             echo "Setting up default dev shell..."
+
+            DEPS_CACHE_TMP="/tmp/clojure_cache_gensql_query"
+            echo "Using read-write clojure cache at:"
+            echo "$DEPS_CACHE_TMP"
+
+            cache_signature_file="/tmp/clojure_cache_gensql_query_signature"
+            cache_signature="$(echo ${depsCache} | tr -d '\n')"
+            last_cache_signature="$(cat $cache_signature_file | tr -d '\n')"
+
+            if [[ $cache_signature != $last_cache_signature ]]; then
+              echo -n $cache_signature > $cache_signature_file
+
+              mkdir -p $DEPS_CACHE_TMP
+              echo "Copying readonly clojure cache to read-write location"
+              rsync -LrltgoD --chmod=ug+w ${depsCache}/ $DEPS_CACHE_TMP/
+            fi
+
+            export CLJ_CONFIG="$DEPS_CACHE_TMP/.clojure"
+            export GITLIBS="$DEPS_CACHE_TMP/.gitlibs"
+            export JAVA_TOOL_OPTIONS="-Duser.home=$DEPS_CACHE_TMP"
+          '';
+        };
+
+        # development shell with readonly dependencies
+        devShells.strict = pkgs.mkShell {
+          buildInputs = [ pkgs.openjdk21 pkgs.clojure pkgs.babashka depsCache ] ++ (basicToolsFn pkgs);
+
+          shellHook = ''
+            echo "Setting up strict dev shell with readonly clojure deps..."
             export CLJ_CONFIG="${depsCache}/.clojure"
             export GITLIBS="${depsCache}/.gitlibs"
             export JAVA_TOOL_OPTIONS="-Duser.home=${depsCache}"


### PR DESCRIPTION
This PR splits the current, strict devshell experience (depsCache is set to a readonly nix-store directory, and is therefore very stable, but harder to iterate on) to `.#strict` devshell; the default shell, used with `direnv`, still downloads the existing deps but sets maven and clojure to use a temp directory, and copies the deps directly into that location.

Along the way, two fixes are included:
1. use `MAVEN_OPTS` instead of `JAVA_TOOL_OPTS user.home`, becuase it is more exact.
2. stop using the tag reference for test-runner dependency, which was breaking the use of depsCache for unknown reasons.

@KingMob , (2) implies that in the short term, it will be necessary to refer by full sha instead of tag and short sha to git dependencies. I am unclear why this is the case, as it seems related but not identical to https://github.com/jlesquembre/clj-nix/issues/88 . I hope you are okay with this adaptation in the short term while we figure out the cause of that behavior; please share any concerns here.