### PR TITLE
Make parens optional for `* EXCEPT` and minor clean up 

### DIFF
--- a/resources/inferenceql/query/base.bnf
+++ b/resources/inferenceql/query/base.bnf
@@ -81,8 +81,9 @@ select-list ::= select-star-clause
               / aggregation (ws? ',' ws? aggregation)*
 
 star ::= '*'
-select-star-clause ::= star (ws? select-except-clause)?
-select-except-clause ::= #'(?i)EXCEPT' ws? '(' ws? identifier-list ws? ')'
+<select-star-clause> ::= star (ws? select-except-clause)?
+select-except-clause ::= #'(?i)EXCEPT' (ws identifier-list | ws? <'('> ws? identifier-list ws? <')'>)
+
 
 selection ::= (scalar-expr | aggregation) (ws alias-clause)?
 

--- a/resources/inferenceql/query/base.bnf
+++ b/resources/inferenceql/query/base.bnf
@@ -229,7 +229,7 @@ density-event-group ::= '(' ws? density-event ws? ')'
 
 conditioned-by-expr ::= model-expr ws #'(?i)CONDITIONED' ws #'(?i)BY' ws (conditioned-by-star-clause | density-event)
 <conditioned-by-star-clause> ::= star (ws? conditioned-by-except-clause)?
-conditioned-by-except-clause ::= #'(?i)EXCEPT' (ws? <'('> ws? model-var-list ws? <')'> | ws model-var-list)
+conditioned-by-except-clause ::= #'(?i)EXCEPT' (ws model-var-list | ws? <'('> ws? model-var-list ws? <')'>)
 
 
 incorporate-expr ::= #'(?i)INCORPORATE' ws relation-expr ws #'(?i)INTO' ws model-expr

--- a/resources/inferenceql/query/base.bnf
+++ b/resources/inferenceql/query/base.bnf
@@ -189,8 +189,9 @@ join-expr-group ::= '(' join-expr ')'
 generate-expr ::= #'(?i)GENERATE' ws generate-list ws #'(?i)UNDER' ws model-expr
 <generate-list> ::= generate-star-clause
                   / model-var-list
-generate-star-clause ::= star (ws? generate-except-clause)?
-generate-except-clause ::= #'(?i)EXCEPT' ws? '(' ws? model-var-list ws? ')'
+<generate-star-clause> ::= star (ws generate-except-clause)?
+generate-except-clause ::= #'(?i)EXCEPT' (ws model-var-list | ws? <'('> ws? model-var-list ws? <')'>)
+
 
 (* generative-join-expr *)
 

--- a/src/inferenceql/query/permissive.cljc
+++ b/src/inferenceql/query/permissive.cljc
@@ -128,6 +128,8 @@
                               nodes)]
       [:generate-expr generate ws variable-list ws under ws model])
 
+    [[:generate-except-clause except [:identifier-list & nodes]]]
+    [:generate-except-clause except ws (identifier-list->variable-list (into [:identifier-list] nodes))]
     [[:generate-except-clause except "(" [:identifier-list & nodes] ")"]]
     [:generate-except-clause except ws "(" (identifier-list->variable-list (into [:identifier-list] nodes)) ")"]
 

--- a/src/inferenceql/query/plan.cljc
+++ b/src/inferenceql/query/plan.cljc
@@ -235,18 +235,14 @@
 (defmethod plan-impl :generate-expr
   [node]
   (tree/match [node]
-    [[:generate-expr _generate generate-list _under model-expr]]
-    (let [sexpr (scalar/plan model-expr)]
-      (tree/match [generate-list]
-        [[:generate-star-clause [:star & _]]]
-        (generate :* sexpr :include)
+    [[:generate-expr _generate [:star & _] _under model-expr]]
+    (generate :* (scalar/plan model-expr) :include)
 
-        [[:generate-star-clause [:star & _]
-          [:generate-except-clause _except _lparen (:or [:variable-list & variables] [:identifier-list & variables]) _rparen]]]
-        (generate (map variable-node->string (filter tree/branch? variables)) sexpr :exclude)
+    [[:generate-expr _generate [:star & _] [:generate-except-clause _except (:or [:variable-list & variables] [:identifier-list & variables])] _under model-expr]]
+    (generate (map variable-node->string (filter tree/branch? variables)) (scalar/plan model-expr) :exclude)
 
-        [[:variable-list & variables]]
-        (generate (map variable-node->string (filter tree/branch? variables)) sexpr :include)))))
+    [[:generate-expr _generate [:variable-list & variables] _under model-expr]]
+    (generate (map variable-node->string (filter tree/branch? variables)) (scalar/plan model-expr) :include)))
 
 (defmethod plan-impl :where-clause
   [node op]

--- a/test/inferenceql/query/base/parser_test.cljc
+++ b/test/inferenceql/query/base/parser_test.cljc
@@ -1,4 +1,7 @@
 (ns inferenceql.query.base.parser-test
+  "Tests for parsing common GenSQL queries. Tests against both strict and
+  permissive parsers. Tests against either the strict or permissive variants
+  should go in their respective test files."
   (:require [clojure.test :refer [deftest testing is]]
             [inferenceql.query.parser.tree :as tree]
             [inferenceql.query.strict.parser :as strict.parser]
@@ -110,3 +113,10 @@
 
 (deftest parse-generate-star
   (parses "GENERATE * UNDER model" :generate-expr))
+
+(deftest select-star
+  (parses "SELECT *" :select-clause)
+  (parses "SELECT * EXCEPT foo" :select-clause)
+  (parses "SELECT * EXCEPT foo, bar" :select-clause)
+  (parses "SELECT * EXCEPT (foo, bar)" :select-clause)
+  (parses "SELECT * EXCEPT(x,y,z)" :select-clause))

--- a/test/inferenceql/query/plan_test.cljc
+++ b/test/inferenceql/query/plan_test.cljc
@@ -230,7 +230,8 @@
 
 (deftest generate
   (testing "attributes"
-    (are [query attrs] (= attrs (relation/attributes (eval query {"model" model})))
+    (are [query attrs]
+      (= attrs (relation/attributes (eval query {"model" model})))
       "GENERATE VAR x UNDER model" ["x"]
       "GENERATE VAR x, VAR y UNDER model" ["x" "y"]
       "GENERATE VAR y, VAR x UNDER model" ["y" "x"]
@@ -239,7 +240,6 @@
   (testing "values"
     (let [rel (eval "GENERATE VAR x UNDER model" {"model" model})]
       (doseq [tup (relation/tuples (take 1 #_ 5 rel))]
-        ;;(tap> #:tup{:tup tup})
         (is (= ["x"] (keys tup)))
         (is (contains? #{"yes" "no"} (tuple/get tup "x")))))))
 

--- a/test/inferenceql/query/plan_test.cljc
+++ b/test/inferenceql/query/plan_test.cljc
@@ -17,6 +17,7 @@
     "SELECT * FROM data"
     "SELECT x FROM data"
     "SELECT (x) FROM data"
+    "SELECT * EXCEPT x,y,z FROM data"
     "SELECT * EXCEPT (foo, bar) FROM data"
     "SELECT PROBABILITY OF VAR x = x UNDER model FROM data"
     "SELECT (PROBABILITY OF VAR x = x UNDER model) FROM data"))
@@ -30,6 +31,7 @@
     "SELECT * FROM data"
     "SELECT x FROM data"
     "SELECT (x) FROM data"
+    "SELECT * EXCEPT x,y,z FROM data"
     "SELECT * EXCEPT (foo, bar) FROM data"
     "SELECT PROBABILITY OF x UNDER model FROM data"
     "SELECT (PROBABILITY OF x UNDER model) FROM data"))


### PR DESCRIPTION
This makes parentheses optional for the `SELECT * EXCEPT` and `GENERATE * EXCEPT` code, which were not originally created that way.

It also adds a few missing parse tests, and simplifies and aligns their parse trees and plans.